### PR TITLE
Ajout d'une méthode (prune_acos) pour supprimer les acos caducs de l'acl

### DIFF
--- a/controllers/acos_controller.php
+++ b/controllers/acos_controller.php
@@ -36,6 +36,21 @@ class AcosController extends AclAppController {
 	    }
 	}
 	
+	function admin_prune_acos($run = null)
+	{
+	    if(isset($run))
+	    {
+    		$logs = $this->AclManager->prune_acos();
+
+    		$this->set('logs', $logs);
+    		$this->set('run', true);
+	    }
+	    else
+	    {
+	        $this->set('run', false);
+	    }
+	}
+	
 	function admin_build_acl($run = null)
 	{
 	    if(isset($run))

--- a/controllers/components/acl_reflector.php
+++ b/controllers/components/acl_reflector.php
@@ -139,7 +139,14 @@ class AclReflectorComponent
     						}
     						else
     						{
-    						    $plugins_controllers[] = array('file' => $fileName, 'name' => Inflector::humanize($plugin_name) . "/" . $controller_class_name);
+    						    
+    							if ($filter_default_controller)
+    							{
+    								$plugins_controllers[] = array('file' => $fileName, 'name' => Inflector::humanize($plugin_name) . "/" . $controller_class_name);
+    							}
+    							else {
+    								$plugins_controllers[] = array('file' => $fileName, 'name' => $controller_class_name);
+    							}
     						}
     					}
 					}

--- a/views/acos/admin_prune_acos.ctp
+++ b/views/acos/admin_prune_acos.ctp
@@ -1,0 +1,42 @@
+<?php
+echo $this->element('design/header');
+?>
+
+<?php
+echo $this->element('acos/links');
+?>
+
+<?php
+if($run)
+{
+    if(count($logs) > 0)
+    {
+        echo '<p>';
+        echo __d('acl', 'The following actions ACOs have been pruned', true);
+        echo '<p>';
+        echo $this->Html->nestedList($logs);
+    }
+    else
+    {
+        echo '<p>';
+        echo __d('acl', 'There was no ACOs to prune', true);
+        echo '</p>';
+    }
+}
+else
+{
+    echo '<p>';
+    echo __d('acl', 'This page allows you to prune superfluous ACOs (any ACO pointing to controllers and actions that have been removed).', true);
+    echo '</p>';
+
+    echo '<p>';
+    echo __d('acl', 'Clicking the link will not change or remove permissions for existing actions ACOs.', true);
+    echo '</p>';
+
+    echo '<p>';
+    echo $this->Html->link(__d('acl', 'Prune', true), '/admin/acl/acos/prune_acos/run');
+    echo '</p>';
+}
+
+echo $this->element('design/footer');
+?>

--- a/views/elements/acos/links.ctp
+++ b/views/elements/acos/links.ctp
@@ -4,6 +4,7 @@ $selected = isset($selected) ? $selected : $this->params['action'];
 
 $links = array();
 $links[] = $this->Html->link(__d('acl', 'Build actions ACOs', true), '/admin/acl/acos/build_acl', array('class' => ($selected == 'admin_build_acl' )? 'selected' : null));
+$links[] = $this->Html->link(__d('acl', 'Prune actions ACOs', true), '/admin/acl/acos/prune_acos', array('class' => ($selected == 'admin_prune_acos' )? 'selected' : null));
 $links[] = $this->Html->link(__d('acl', 'Clear actions ACOs', true), '/admin/acl/acos/empty_acos', array(array('confirm' => __d('acl', 'are you sure ?', true)), 'class' => ($selected == 'admin_empty_acos' )? 'selected' : null));
 
 echo $this->Html->nestedList($links, array('class' => 'acl_links'));


### PR DESCRIPTION
Hello nIcO,

j'ai ajouté une fonctionnalité prune_acos dans ton plugin (par ailleurs excellent). Cette fonctionnalité permet de supprimer tous les ACOSs (actions/contrôleurs) caducs (supprimés) de la table acos, sans toucher aux actions/contrôleurs qui existent toujours (contrairement à la méthode empty_acos). Cela permet de nettoyer la base de données acl. J'ai testé la méthode avec succès chez moi, elle semble parfaitement fonctionner...

Qu'en penses-tu?

Séb
